### PR TITLE
fix: keep GeoJSON/SVG annotation strokes visible at any zoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamerlane",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamerlane",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@allmaps/transform": "1.0.0-beta.52",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamerlane",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A lightweight IIIF viewer for exploring, navigating, and searching annotated IIIF Presentation 3.0 resources",
   "private": true,
   "homepage": "https://tamerlaneviewer.github.io/tamerlane",

--- a/src/service/geojson.ts
+++ b/src/service/geojson.ts
@@ -91,17 +91,19 @@ function ringToPolygon(coords: GeoPoint[], transform: PointTransform): string {
     coords[0][1] === coords[coords.length - 1][1];
   const ring = closed ? coords.slice(0, -1) : coords;
   const points = ring.map((c) => pointString(transform(c))).join(' ');
-  return `<polygon points="${points}" fill="rgba(255,0,0,0.2)" stroke="red" stroke-width="2"/>`;
+  return `<polygon points="${points}" fill="rgba(255,0,0,0.2)" stroke="red" stroke-width="2" vector-effect="non-scaling-stroke"/>`;
 }
 
 function lineToPolyline(coords: GeoPoint[], transform: PointTransform): string {
   const points = coords.map((c) => pointString(transform(c))).join(' ');
-  return `<polyline points="${points}" fill="none" stroke="red" stroke-width="2"/>`;
+  // A single red route line. `non-scaling-stroke` keeps its on-screen width
+  // constant at any zoom.
+  return `<polyline points="${points}" fill="none" stroke="red" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>`;
 }
 
 function pointToCircle(coord: GeoPoint, transform: PointTransform): string {
   const p = transform(coord);
-  return `<circle cx="${round(p[0])}" cy="${round(p[1])}" r="5" fill="rgba(255,0,0,0.4)" stroke="red" stroke-width="2"/>`;
+  return `<circle cx="${round(p[0])}" cy="${round(p[1])}" r="5" fill="rgba(255,0,0,0.4)" stroke="red" stroke-width="2" vector-effect="non-scaling-stroke"/>`;
 }
 
 function geometryToShapes(

--- a/src/utils/sanitizeSvg.test.ts
+++ b/src/utils/sanitizeSvg.test.ts
@@ -1,0 +1,33 @@
+import { sanitizeSvg } from './sanitizeSvg.ts';
+
+describe('sanitizeSvg', () => {
+  it('preserves vector-effect="non-scaling-stroke" on overlay geometry', () => {
+    // Overlays rely on vector-effect to keep the stroke a constant width on
+    // screen at any zoom. It is not in DOMPurify's default SVG allowlist, so a
+    // regression here silently makes lines scale down to sub-pixel widths.
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">' +
+      '<polyline points="0,0 100,100" fill="none" stroke="red" ' +
+      'stroke-width="3" vector-effect="non-scaling-stroke"/></svg>';
+
+    const result = sanitizeSvg(svg);
+
+    expect(result).toContain('vector-effect="non-scaling-stroke"');
+  });
+
+  it('strips <script> content but keeps drawable shapes', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">' +
+      '<script>alert(1)</script>' +
+      '<circle cx="5" cy="5" r="4"/></svg>';
+
+    expect(() =>
+      sanitizeSvg(svg, { disallowedTags: ['script'] }),
+    ).toThrow(/disallowed <script>/);
+  });
+
+  it('throws when the SVG exceeds the max length', () => {
+    const big = '<svg>' + 'a'.repeat(1000) + '</svg>';
+    expect(() => sanitizeSvg(big, { maxLength: 100 })).toThrow(/max length/);
+  });
+});

--- a/src/utils/sanitizeSvg.ts
+++ b/src/utils/sanitizeSvg.ts
@@ -36,6 +36,13 @@ export function sanitizeSvg(
         }
     }
 
-    // 4. Sanitize using DOMPurify with SVG-safe profile
-    return DOMPurify.sanitize(svgString, { USE_PROFILES: { svg: true } });
+    // 4. Sanitize using DOMPurify with SVG-safe profile. `vector-effect` is a
+    // safe SVG presentation attribute but is not in DOMPurify's default SVG
+    // allowlist, so add it explicitly — overlays rely on
+    // `vector-effect="non-scaling-stroke"` to keep line width constant on
+    // screen at any zoom.
+    return DOMPurify.sanitize(svgString, {
+        USE_PROFILES: { svg: true },
+        ADD_ATTR: ['vector-effect'],
+    });
 }


### PR DESCRIPTION
DOMPurify's default SVG profile strips the `vector-effect` attribute, so `non-scaling-stroke` never applied and overlay strokes scaled down with the viewBox to sub-pixel widths on large georeferenced maps — making lines
effectively invisible.